### PR TITLE
Implement selective verified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y chezscheme curl build-essential
+
+      - name: Install pack
+        run: |
+          bash -c "$(curl -fsSL https://raw.githubusercontent.com/stefan-hoeck/idris2-pack/main/install.bash)"
+
+      - name: Add pack to PATH
+        run: |
+          echo "$HOME/.pack/bin" >> "$GITHUB_PATH"
+
+      - name: Select Idris 2
+        run: |
+          pack switch latest
+          pack info
+
+      - name: Build
+        run: |
+          pack build selective.ipkg

--- a/selective.ipkg
+++ b/selective.ipkg
@@ -1,5 +1,6 @@
 package selective
 
-sourcedir = src
+sourcedir = "src"
 
 modules = Control.Selective
+  , Control.Selective.Verified

--- a/selective.ipkg
+++ b/selective.ipkg
@@ -1,6 +1,12 @@
 package selective
 
+brief = "Selective functors in Idris 2"
+version = 0.0.1
+readme = "README.md"
+sourceloc = "https://github.com/clayrat/idris-selective"
+bugtracker = "https://github.com/clayrat/idris-selective/issues"
+
 sourcedir = "src"
 
 modules = Control.Selective
-  , Control.Selective.Verified
+        , Control.Selective.Verified

--- a/src/Control/Selective.idr
+++ b/src/Control/Selective.idr
@@ -2,6 +2,7 @@ module Control.Selective
 
 %default total
 
+public export
 interface Applicative f => Selective f where
   select : f (Either a b) -> f (a -> b) -> f b
 

--- a/src/Control/Selective.idr
+++ b/src/Control/Selective.idr
@@ -6,15 +6,19 @@ public export
 interface Applicative f => Selective f where
   select : f (Either a b) -> f (a -> b) -> f b
 
+public export
 branch : Selective f => f (Either a b) -> f (a -> c) -> f (b -> c) -> f c
 branch fe fac fbc = select (select (map (map Left) fe) (map (\ac => Right . ac) fac)) fbc
 
+public export
 apS : Selective f => f (a -> b) -> f a -> f b
 apS fab fa = select (map Left fab) (map (flip apply) fa)
 
+public export
 selectM : Monad f => f (Either a b) -> f (a -> b) -> f b
 selectM fe fab = fe >>= \case Left a => map (\ab => ab a) fab
                               Right b => pure b
 
+public export
 ifS : Selective f => f Bool -> f a -> f a -> f a
 ifS fb ft ff = branch (map (\b => if b then Left () else Right ()) fb) (map const ft) (map const ff)

--- a/src/Control/Selective/Verified.idr
+++ b/src/Control/Selective/Verified.idr
@@ -1,4 +1,12 @@
 module Control.Selective.Verified
 
+import Control.Selective
+import Data.Either
+import Control.Monad.Either
+
 %default total
 
+export
+interface (Selective f) => VerifiedSelective (f : Type -> Type) where
+  selectiveIdentity : {a : Type} -> {x : f a} ->
+                      select x (pure Basics.id) = either Basics.id Basics.id <$> x

--- a/src/Control/Selective/Verified.idr
+++ b/src/Control/Selective/Verified.idr
@@ -2,11 +2,12 @@ module Control.Selective.Verified
 
 import Control.Selective
 import Data.Either
-import Control.Monad.Either
 
 %default total
 
-export
-interface (Selective f) => VerifiedSelective (f : Type -> Type) where
-  selectiveIdentity : {a : Type} -> {x : f a} ->
-                      select x (pure Basics.id) = either Basics.id Basics.id <$> x
+public export
+interface Selective f => VerifiedSelective (f : Type -> Type) where
+  selectiveIdentity :
+    {0 a : Type} ->
+    (x : f (Either a a)) ->
+    select x (pure Basics.id) = map (either Basics.id Basics.id) x

--- a/src/Control/Selective/Verified.idr
+++ b/src/Control/Selective/Verified.idr
@@ -11,3 +11,9 @@ interface Selective f => VerifiedSelective (f : Type -> Type) where
     {0 a : Type} ->
     (x : f (Either a a)) ->
     select x (pure Basics.id) = map (either Basics.id Basics.id) x
+
+  selectiveDistributivity :
+    {0 a, b : Type} ->
+    (x : f (Either a b)) ->
+    (y : a -> b) ->
+    select x (pure y) = map (either y Basics.id) x


### PR DESCRIPTION
* add CI using GithubActions
* introduces a VerifiedSelective interface for lawful Selective instances
     * identity law of select

Haskell states: `x <*? pure id = either id id <$> x` 
But `x` must have type: `f (Either a a)`  not `f a`, because select expects its first argument to be `f (Either a b)` so we get:
```idris
selectiveIdentity :
  {0 a : Type} ->
  (x : f (Either a a)) ->
  select x (pure Basics.id) = map (either Basics.id Basics.id) x
```
    * distributivity law (from @lemastero fork)

*exports the verified interface so downstream code can depend on it